### PR TITLE
Fix failing gradle build issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.github.ben-manes.versions" version "0.20.0"
+}
+
 subprojects {
     apply plugin: 'idea'
 
@@ -5,9 +9,9 @@ subprojects {
     version '1.0.0'
 
     ext {
-        protobufVersion = '3.6.0'
-        proteusVersion = '0.9.0'
-        rsocketRpcVersion = '0.2.0'
+        protobufVersion = '3.6.1'
+        proteusVersion = '0.9.5'
+        rsocketRpcVersion = '0.2.4'
         proteusSpringVersion = '0.4.2'
         springbomVersion = 'Cairo-SR1'
     }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'org.springframework.boot' version '2.0.2.RELEASE'
+    id 'org.springframework.boot' version '2.0.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
 }
 

--- a/service-idl/build.gradle
+++ b/service-idl/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.google.protobuf' version '0.8.5'
+    id 'com.google.protobuf' version '0.8.6'
     id 'java'
 }
 
@@ -7,7 +7,7 @@ sourceCompatibility = 1.8
 
 dependencies {
     compile "io.netifi.proteus:proteus-client:$proteusVersion"
-    compile 'com.google.protobuf:protobuf-java:3.6.0'
+    compile "com.google.protobuf:protobuf-java:$protobufVersion"
 }
 
 sourceSets {
@@ -24,7 +24,7 @@ protobuf {
     generatedFilesBaseDir = "${projectDir}/src/generated"
 
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.6.0'
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
     }
     plugins {
         rsocketRpc {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'org.springframework.boot' version '2.0.2.RELEASE'
+    id 'org.springframework.boot' version '2.0.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
 }
 


### PR DESCRIPTION
Fix failing gradle build issue https://github.com/netifi/proteus-spring-quickstart/issues/3 by updating libraries.

Note: The quickstart example works after this PR (the gradle version as described in https://www.netifi.com/getstarted-springboot), but I recommend to do some more cleanup...

- Updating Proteus-Spring from 0.4.2 to 0.4.4 did not work -> there is a NullPointerException in the client after the update
- I didn't touch the maven build. There are still the old versions used. I don't know if the Maven build works.
- Update Gradle-Wrapper from 4.10 to 4.10.2
